### PR TITLE
Nullablereftypesetting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# /vs code Workspace settings folder
+.vscode/*

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
@@ -23,8 +23,6 @@ else
 
 @code {
     private IEnumerable<Trail> _trails;
-    
-    #nullable enable
     private Trail? _selectedTrail;
 
     protected override async Task OnInitializedAsync()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
@@ -23,7 +23,8 @@ else
 
 @code {
     private IEnumerable<Trail> _trails;
-#nullable enable
+
+    #nullable enable
     private Trail? _selectedTrail;
 
     protected override async Task OnInitializedAsync()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
@@ -23,6 +23,8 @@ else
 
 @code {
     private IEnumerable<Trail> _trails;
+    
+    #nullable enable
     private Trail? _selectedTrail;
 
     protected override async Task OnInitializedAsync()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/HomePage.razor
@@ -23,6 +23,7 @@ else
 
 @code {
     private IEnumerable<Trail> _trails;
+#nullable enable
     private Trail? _selectedTrail;
 
     protected override async Task OnInitializedAsync()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
@@ -24,6 +24,7 @@
 @code {
     private bool _isOpen;
 
+    #nullable enable
     [Parameter] public Trail? Trail { get; set; }
 
     protected override void OnParametersSet()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
@@ -23,7 +23,8 @@
 
 @code {
     private bool _isOpen;
-
+    
+#nullable enable
     [Parameter] public Trail? Trail { get; set; }
 
     protected override void OnParametersSet()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
@@ -24,7 +24,6 @@
 @code {
     private bool _isOpen;
 
-    #nullable enable
     [Parameter] public Trail? Trail { get; set; }
 
     protected override void OnParametersSet()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
@@ -24,7 +24,7 @@
 @code {
     private bool _isOpen;
     
-#nullable enable
+    #nullable enable
     [Parameter] public Trail? Trail { get; set; }
 
     protected override void OnParametersSet()

--- a/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
+++ b/chapter-03/BlazingTrails/BlazingTrails.Web/Features/Home/TrailDetails.razor
@@ -24,6 +24,7 @@
 @code {
     private bool _isOpen;
 
+#nullable enable
     [Parameter] public Trail? Trail { get; set; }
 
     protected override void OnParametersSet()


### PR DESCRIPTION
When building in VS Code, I was seeing the following warnings:
C:\Users\m2web\source\repos\dotnet\blazor-in-action\chapter-03\BlazingTrails\BlazingTrails.Web\Features\Home\HomePage.razor(26,18): warning CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source. [C:\Users\m2web\source\repos\dotnet\blazor-in-action\chapter-03\BlazingTrails\BlazingTrails.Web\BlazingTrails.Web.csproj]
C:\Users\m2web\source\repos\dotnet\blazor-in-action\chapter-03\BlazingTrails\BlazingTrails.Web\Features\Home\TrailDetails.razor(27,29): warning CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source. [C:\Users\m2web\source\repos\dotnet\blazor-in-action\chapter-03\BlazingTrails\BlazingTrails.Web\BlazingTrails.Web.csproj]

Looking at https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references I annotated the nullable parameters and the warning is now absent.